### PR TITLE
ci: devops team owns .github folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 
 # Global code owner (WindRanger core team)
-*           @windranger-io/Windranger-core
+*           @windranger-io/windranger-core
 
 # GitHub Actions owners
-/.github/   @CjHare
+/.github/   @windranger-io/windranger-core


### PR DESCRIPTION
The `.github` directory contains GitHub related configuration, including the action used for CI. This is the remit of a devops team.